### PR TITLE
Implement detaching from the debugging server

### DIFF
--- a/pugdebug/debugger.py
+++ b/pugdebug/debugger.py
@@ -53,6 +53,9 @@ class PugdebugDebugger(QObject):
             self.handle_server_cancelled
         )
         self.server.server_stopped_signal.connect(self.handle_server_stopped)
+        self.server.server_detached_signal.connect(
+            self.handle_server_detached
+        )
         self.server.server_stepped_signal.connect(self.handle_server_stepped)
         self.server.server_got_variables_signal.connect(
             self.handle_server_got_variables
@@ -127,6 +130,20 @@ class PugdebugDebugger(QObject):
         """Handle when server gets disconnected
 
         Emit a debugging stopped signal.
+        """
+        self.debugging_stopped_signal.emit()
+
+    def detach_debug(self):
+        """Detach a debugging session
+        """
+        self.server.detach()
+
+    def handle_server_detached(self):
+        """Handle when server gets ditached
+
+        Emit a debugging stopped signal, as the
+        debugger should behave the same like when
+        a debugging session is stopped.
         """
         self.debugging_stopped_signal.emit()
 

--- a/pugdebug/gui/main_window.py
+++ b/pugdebug/gui/main_window.py
@@ -128,6 +128,14 @@ class PugdebugMainWindow(QMainWindow):
         )
         self.stop_debug_action.setShortcut(QKeySequence("F2"))
 
+        self.detach_debug_action = toolbar.addAction("Detach")
+        self.detach_debug_action.setToolTip("Detach from server (F3)")
+        self.detach_debug_action.setStatusTip(
+            "Stop the debugging session, but let the PHP process end normally."
+            " Shortcut: F3"
+        )
+        self.detach_debug_action.setShortcut(QKeySequence("F3"))
+
         self.run_debug_action = toolbar.addAction("Run")
         self.run_debug_action.setToolTip("Start/resume the script (F5)")
         self.run_debug_action.setStatusTip(
@@ -168,6 +176,7 @@ class PugdebugMainWindow(QMainWindow):
         self.addToolBar(toolbar)
 
     def toggle_actions(self, enabled):
+        self.detach_debug_action.setEnabled(enabled)
         self.run_debug_action.setEnabled(enabled)
         self.step_over_action.setEnabled(enabled)
         self.step_into_action.setEnabled(enabled)

--- a/pugdebug/pugdebug.py
+++ b/pugdebug/pugdebug.py
@@ -123,6 +123,9 @@ class Pugdebug(QObject):
         """
         self.main_window.start_debug_action.triggered.connect(self.start_debug)
         self.main_window.stop_debug_action.triggered.connect(self.stop_debug)
+        self.main_window.detach_debug_action.triggered.connect(
+            self.detach_debug
+        )
         self.main_window.run_debug_action.triggered.connect(self.run_debug)
         self.main_window.step_over_action.triggered.connect(self.step_over)
         self.main_window.step_into_action.triggered.connect(self.step_into)
@@ -341,6 +344,15 @@ class Pugdebug(QObject):
         self.main_window.toggle_actions(False)
 
         self.main_window.set_statusbar_text("Debugging stopped...")
+
+    def detach_debug(self):
+        """Detach a debugging session.
+
+        The debugging session will end, but the debuged script
+        will terminate normally.
+        """
+        if self.debugger.is_connected():
+            self.debugger.detach_debug()
 
     def handle_step_command(self):
         """Handle step command

--- a/pugdebug/server.py
+++ b/pugdebug/server.py
@@ -41,6 +41,7 @@ class PugdebugServer(QThread):
     server_connected_signal = pyqtSignal(dict)
     server_cancelled_signal = pyqtSignal()
     server_stopped_signal = pyqtSignal()
+    server_detached_signal = pyqtSignal()
     server_stepped_signal = pyqtSignal(dict)
     server_got_variables_signal = pyqtSignal(object)
     server_got_stacktraces_signal = pyqtSignal(object)
@@ -72,6 +73,9 @@ class PugdebugServer(QThread):
         elif action == 'stop':
             response = self.__stop()
             self.server_stopped_signal.emit()
+        elif action == 'detach':
+            response = self.__detach()
+            self.server_detached_signal.emit()
         elif action == 'step_run':
             response = self.__step_run()
             self.server_stepped_signal.emit(response)
@@ -132,6 +136,10 @@ class PugdebugServer(QThread):
 
     def stop(self):
         self.action = 'stop'
+        self.start()
+
+    def detach(self):
+        self.action = 'detach'
         self.start()
 
     def step_run(self):
@@ -244,6 +252,12 @@ class PugdebugServer(QThread):
 
     def __stop(self):
         command = 'stop -i %d' % self.__get_transaction_id()
+        self.__send_command(command)
+
+        return True
+
+    def __detach(self):
+        command = 'detach -i %d' % self.__get_transaction_id()
         self.__send_command(command)
 
         return True


### PR DESCRIPTION
Detaching the debugging session allows to stop the debuggin
session, but let the PHP process finish.