### PR TITLE
Do not stop the server when cleaning up

### DIFF
--- a/pugdebug/debugger.py
+++ b/pugdebug/debugger.py
@@ -142,8 +142,6 @@ class PugdebugDebugger(QObject):
             self.current_connection.disconnect()
             self.connections.clear()
 
-        self.server.stop()
-
         self.current_connection = None
         self.step_result = ''
         self.current_file = ''
@@ -246,7 +244,6 @@ class PugdebugDebugger(QObject):
             self.start_new_connection()
         else:
             self.cleanup()
-
             self.debugging_stopped_signal.emit()
 
     def run_debug(self):


### PR DESCRIPTION
This stops the server from listening for new incoming connections
at the incorrect time, missing out on new incoming connections.