### PR TITLE
Install sip and PyQt5 with pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+sip
+PyQt5
 flake8
 Pygments
 pyinstaller


### PR DESCRIPTION
As both sip and PyQt5 are now available on pypi,
add them to requirements.txt for easier installing
with pip.