### PR TITLE
Set application wide mouse cursor

### DIFF
--- a/pugdebug/gui/main_window.py
+++ b/pugdebug/gui/main_window.py
@@ -11,8 +11,8 @@ __author__ = "robertbasic"
 
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (QMainWindow, QToolBar, QMenuBar, QDockWidget,
-                             QAction)
-from PyQt5.QtGui import QFont, QKeySequence
+                             QAction, QApplication)
+from PyQt5.QtGui import QFont, QKeySequence, QCursor
 
 from pugdebug.gui.file_browser import PugdebugFileBrowser
 from pugdebug.gui.settings import PugdebugSettingsWindow
@@ -81,6 +81,12 @@ class PugdebugMainWindow(QMainWindow):
         self.setup_toolbar()
         self.setup_menubar()
         self.setup_statusbar()
+
+        self.setup_mouse_cursor()
+
+    def setup_mouse_cursor(self):
+        cursor = QCursor(Qt.ArrowCursor)
+        QApplication.setOverrideCursor(cursor)
 
     def setup_statusbar(self):
         self.permanent_statusbar = PugdebugStatusBar()


### PR DESCRIPTION
Set an override mouse cursor application-wide
so we don't have an IBeamCursor on the plain text widget
where the source code is displayed.

Couldn't figure out how to change the cursor only on the plain
text widget, so did an application wide change instead.