### PR TITLE
Change order of save and cancel buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
  - File watching for Windows OS
  - Connecting to document signals when document is changed or removed
+ - Focus of buttons in the New Project window, save has focus by default
 
 ### Removed
 

--- a/pugdebug/gui/projects.py
+++ b/pugdebug/gui/projects.py
@@ -50,8 +50,8 @@ class PugdebugNewProjectWindow(QDialog):
         cancel_button.clicked.connect(self.reject)
 
         button_layout = QHBoxLayout()
-        button_layout.addWidget(cancel_button)
         button_layout.addWidget(save_button)
+        button_layout.addWidget(cancel_button)
 
         box_layout = QVBoxLayout()
         box_layout.addLayout(project_name_layout)


### PR DESCRIPTION
This way when we hit enter in the new project window,
the save button will be the default one and not cancel.

It is also now the same as the settings window.